### PR TITLE
Download providers from official site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .DS_Store
+
+.terraform.d

--- a/.terraform.d/plugins/registry.terraform.io/hashicorp/random/3.1.0/linux_amd64/terraform-provider-random_v3.1.0_x5
+++ b/.terraform.d/plugins/registry.terraform.io/hashicorp/random/3.1.0/linux_amd64/terraform-provider-random_v3.1.0_x5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e30c512b52e27a2ef23c9b6d2afca274627e06a5739bf2df5dd60dbc8895aea6
-size 13205504

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,18 @@ RUN \
   pip install azure-cli && \
   apk del --purge build
 
+RUN wget https://releases.hashicorp.com/terraform-provider-random/3.1.0/terraform-provider-random_3.1.0_linux_amd64.zip &&  \
+    unzip terraform-provider-random_3.1.0_linux_amd64.zip && \
+    chmod +x terraform-provider-random_v3.1.0_x5 && \
+    mkdir -p .terraform.d/plugins/registry.terraform.io/hashicorp/random/3.1.0/linux_amd64 && \
+    mv terraform-provider-random_v3.1.0_x5 .terraform.d/plugins/registry.terraform.io/hashicorp/random/3.1.0/linux_amd64 && \
+    rm -f terraform-provider-random_3.1.0_linux_amd64.zip
+
+RUN wget https://releases.hashicorp.com/terraform-provider-alicloud/1.140.0/terraform-provider-alicloud_1.140.0_linux_amd64.zip && \
+    unzip terraform-provider-alicloud_1.140.0_linux_amd64.zip && \
+    chmod +x terraform-provider-alicloud_v1.140.0 && \
+    mkdir -p .terraform.d/plugins/registry.terraform.io/hashicorp/alicloud/1.140.0/linux_amd64 && \
+    mv terraform-provider-alicloud_v1.140.0 .terraform.d/plugins/registry.terraform.io/hashicorp/alicloud/1.140.0/linux_amd64 && \
+    rm -f terraform-provider-alicloud_1.140.0_linux_amd64.zip
+
 COPY .terraform.d /root/.terraform.d


### PR DESCRIPTION
Instead of storing providers in Github LFS, downloading it from Hashicorp
official site.